### PR TITLE
Improved error handling when price cannot be read

### DIFF
--- a/check_price.py
+++ b/check_price.py
@@ -25,7 +25,10 @@ while True:
     try:
         price = define_price()
         break
-    except NameError:
+    except NameError as e:
+        logging.exception("An error occurred: %s", e)
+        pass
+    except ValueError as e:
         logging.exception("An error occurred: %s", e)
         pass
     finally:

--- a/tweet.py
+++ b/tweet.py
@@ -39,7 +39,10 @@ while True:
     try:
         price = define_price()
         break
-    except NameError:
+    except NameError as e:
+        logger.exception("An error occurred: %s", e)
+        pass
+    except ValueError as e:
         logger.exception("An error occurred: %s", e)
         pass
     finally:


### PR DESCRIPTION
When price cannot be read the value is None. When that happens tweet.py raises ValueError exception (that should be added also into check_price.py, I did not do that). But that exception was never handled.

This improvement catches ValueError in tweet.py, also some minor correction was done when catching NameError.